### PR TITLE
Remove shading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,40 +19,6 @@
 
     <build>
         <finalName>DisplayModelLib</finalName>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.4.1</version>
-                <configuration>
-                    <relocations>
-                        <relocation>
-                            <pattern>dev.sefiraat.sefilib</pattern>
-                            <shadedPattern>org.metamechanists.displaymodellib.sefilib</shadedPattern>
-                        </relocation>
-                    </relocations>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>META-INF/*</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
         <resources>
             <resource>
                 <directory>src/main/resources</directory>


### PR DESCRIPTION
Shading stuff into a library meant for consumption by other applications is, frankly, a bad idea. For example, suppose a library that both my application and this library require exists (aka a transient dependency). If it is shaded into this lib, I cannot (for example) add it as a `provided`/`compileOnly` dependency, because it is shaded into this lib and therefore my application. Thanks to the Magic of Maven™, unshading the dependencies will not break anything else, because all it's dependencies will still be specified as transient dependencies.